### PR TITLE
remove redundant ts compile before build in prebuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "start": "node dist/server",
         "start:dev": "cross-env NODE_ENV=development tsx src/server.ts",
         "start:prod": "cross-env NODE_ENV=production PORT=80 node dist/server",
-        "prebuild": "npm run lint && npm run tsc && del-cli dist",
+        "prebuild": "npm run lint && del-cli dist",
         "build": "tsc --project tsconfig.build.json",
         "build:skip": "del-cli dist && tsc --project tsconfig.build.json",
         "dev": "nodemon",


### PR DESCRIPTION
Previously prebuild ran tsc then immediately deleted dist, and build ran tsc again. That caused an unnecessary double compilation and confusing order of operations.
The new order runs lint, cleans dist, then runs the single production build — faster and deterministic.