### PR TITLE
fix: resolve ESM import paths using typescript-transform-paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
                 "tsx": "^4.19.3",
                 "typescript": "^5.8.3",
                 "typescript-eslint": "^8.30.1",
+                "typescript-transform-paths": "^3.5.5",
                 "typescript-transformer-esm": "^1.1.0",
                 "vitest": "^3.1.1"
             },
@@ -13233,6 +13234,19 @@
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0",
                 "typescript": ">=4.8.4 <5.9.0"
+            }
+        },
+        "node_modules/typescript-transform-paths": {
+            "version": "3.5.5",
+            "resolved": "https://registry.npmjs.org/typescript-transform-paths/-/typescript-transform-paths-3.5.5.tgz",
+            "integrity": "sha512-RMK86wKe/4+ad+3kMT9SKAs3K0tUHLe7hF+MLbD6VpC9VUmFuKorhf3pHz+qO5GdS4mUp2ncNUo14j6ws9UvBQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "minimatch": "^9.0.5"
+            },
+            "peerDependencies": {
+                "typescript": ">=3.6.5"
             }
         },
         "node_modules/typescript-transformer-esm": {

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
         "tsx": "^4.19.3",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.30.1",
+        "typescript-transform-paths": "^3.5.5",
         "typescript-transformer-esm": "^1.1.0",
         "vitest": "^3.1.1"
     }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -12,12 +12,21 @@
         "esModuleInterop": false,
         "plugins": [
             {
+                "transform": "typescript-transform-paths"
+            },
+            {
                 "transform": "typescript-transformer-esm",
                 "after": true
+            },
+            {
+                "transform": "typescript-transform-paths",
+                "afterDeclarations": true
             }
         ]
     },
-    "include": ["src/**/*"],
+    "include": [
+        "src/**/*"
+    ],
     "exclude": [
         "node_modules",
         "**/*.test.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,11 @@
 {
     "compilerOptions": {
         "baseUrl": "./src/",
+        "paths": {
+            "routes/*": [
+                "routes/*"
+            ]
+        },
         "target": "esnext",
         "module": "esnext",
         "esModuleInterop": true,
@@ -21,7 +26,9 @@
         "noUnusedLocals": true
     },
     "ts-node": {
-        "require": ["tsconfig-paths/register"]
+        "require": [
+            "tsconfig-paths/register"
+        ]
     },
     "include": [
         "src/**/*",


### PR DESCRIPTION
## Problem
After building the project, ESM imports were missing proper relative paths and `.js` extensions, causing runtime errors when starting the server.

Solution 1: TypeScript Transform Paths (This PR)
This PR implements a solution using `typescript-transform-paths` plugin that transforms import paths during TypeScript compilation.
- ⚠️ **Requires explicit path aliases** - each import pattern needs to be defined in `tsconfig.build.json`


## Alternative Solution
See PR [3](https://github.com/Tenemo/expressplate/pull/3) for a Babel-based solution that doesn't require explicit path aliases configuration.
