### PR TITLE
fix: resolve ESM import paths using Babel post-processing

### DIFF
--- a/.babelrc.json
+++ b/.babelrc.json
@@ -1,0 +1,10 @@
+{
+  "plugins": [
+    [
+      "babel-plugin-add-import-extension",
+      {
+        "extension": "js"
+      }
+    ]
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
                 "@typescript-eslint/parser": "^8.30.1",
                 "@vitest/eslint-plugin": "^1.1.42",
                 "babel-jest": "^29.7.0",
+                "babel-plugin-add-import-extension": "^1.6.0",
                 "babel-plugin-module-resolver": "^5.0.2",
                 "core-js": "^3.41.0",
                 "del-cli": "^6.0.0",
@@ -65,11 +66,11 @@
                 "prettier": "^3.5.3",
                 "prettier-eslint": "^16.3.2",
                 "ts-patch": "^3.3.0",
+                "tsc-alias": "^1.8.16",
                 "tsconfig-paths": "^4.2.0",
                 "tsx": "^4.19.3",
                 "typescript": "^5.8.3",
                 "typescript-eslint": "^8.30.1",
-                "typescript-transformer-esm": "^1.1.0",
                 "vitest": "^3.1.1"
             },
             "engines": {
@@ -5003,6 +5004,19 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/babel-plugin-add-import-extension": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-add-import-extension/-/babel-plugin-add-import-extension-1.6.0.tgz",
+            "integrity": "sha512-JVSQPMzNzN/S4wPRoKQ7+u8PlkV//BPUMnfWVbr63zcE+6yHdU2Mblz10Vf7qe+6Rmu4svF5jG7JxdcPi9VvKg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.14.5"
+            },
+            "peerDependencies": {
+                "@babel/core": ">=7.0.0"
             }
         },
         "node_modules/babel-plugin-istanbul": {
@@ -10085,6 +10099,20 @@
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "license": "MIT"
         },
+        "node_modules/mylas": {
+            "version": "2.1.13",
+            "resolved": "https://registry.npmjs.org/mylas/-/mylas-2.1.13.tgz",
+            "integrity": "sha512-+MrqnJRtxdF+xngFfUUkIMQrUUL0KsxbADUkn23Z/4ibGg192Q+z+CQyiYwvWTsYjJygmMR8+w3ZDa98Zh6ESg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/raouldeheer"
+            }
+        },
         "node_modules/nanoid": {
             "version": "3.3.11",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -10929,6 +10957,19 @@
                 "node": ">=4"
             }
         },
+        "node_modules/plimit-lit": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/plimit-lit/-/plimit-lit-1.6.1.tgz",
+            "integrity": "sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "queue-lit": "^1.5.1"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/possible-typed-array-names": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -11661,6 +11702,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/queue-lit": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/queue-lit/-/queue-lit-1.5.2.tgz",
+            "integrity": "sha512-tLc36IOPeMAubu8BkW8YDBV+WyIgKlYU7zUNs0J5Vk9skSZ4JfGlPOqplP0aHdfv7HL0B2Pg6nwiq60Qc6M2Hw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/queue-microtask": {
@@ -13018,6 +13069,38 @@
                 "node": ">=10"
             }
         },
+        "node_modules/tsc-alias": {
+            "version": "1.8.16",
+            "resolved": "https://registry.npmjs.org/tsc-alias/-/tsc-alias-1.8.16.tgz",
+            "integrity": "sha512-QjCyu55NFyRSBAl6+MTFwplpFcnm2Pq01rR/uxfqJoLMm6X3O14KEGtaSDZpJYaE1bJBGDjD0eSuiIWPe2T58g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chokidar": "^3.5.3",
+                "commander": "^9.0.0",
+                "get-tsconfig": "^4.10.0",
+                "globby": "^11.0.4",
+                "mylas": "^2.1.9",
+                "normalize-path": "^3.0.0",
+                "plimit-lit": "^1.2.6"
+            },
+            "bin": {
+                "tsc-alias": "dist/bin/index.js"
+            },
+            "engines": {
+                "node": ">=16.20.2"
+            }
+        },
+        "node_modules/tsc-alias/node_modules/commander": {
+            "version": "9.5.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+            "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || >=14"
+            }
+        },
         "node_modules/tsconfig-paths": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
@@ -13233,19 +13316,6 @@
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0",
                 "typescript": ">=4.8.4 <5.9.0"
-            }
-        },
-        "node_modules/typescript-transformer-esm": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/typescript-transformer-esm/-/typescript-transformer-esm-1.1.0.tgz",
-            "integrity": "sha512-MHLIjH9Oa/NJycV1jEyw//3CsLoncqn4ZlURAwqO5TuRQK5rbVklKQJ8dbeBJKgYA6zV8Q7QrKA3Kt9+kk38DQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=16.0.0"
-            },
-            "peerDependencies": {
-                "typescript": "^4.9.0 || ^5.0.0"
             }
         },
         "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "start:dev": "cross-env NODE_ENV=development tsx src/server.ts",
         "start:prod": "cross-env NODE_ENV=production PORT=80 node dist/server",
         "prebuild": "npm run lint && npm run tsc && del-cli dist",
-        "build": "tsc --project tsconfig.build.json",
+        "build": "tsc --project tsconfig.build.json && tsc-alias -p tsconfig.build.json && babel dist --out-dir dist --extensions .js",
         "build:skip": "del-cli dist && tsc --project tsconfig.build.json",
         "dev": "nodemon",
         "lint": "eslint . --ext js,ts",
@@ -70,6 +70,7 @@
         "@typescript-eslint/parser": "^8.30.1",
         "@vitest/eslint-plugin": "^1.1.42",
         "babel-jest": "^29.7.0",
+        "babel-plugin-add-import-extension": "^1.6.0",
         "babel-plugin-module-resolver": "^5.0.2",
         "core-js": "^3.41.0",
         "del-cli": "^6.0.0",
@@ -89,11 +90,11 @@
         "prettier": "^3.5.3",
         "prettier-eslint": "^16.3.2",
         "ts-patch": "^3.3.0",
+        "tsc-alias": "^1.8.16",
         "tsconfig-paths": "^4.2.0",
         "tsx": "^4.19.3",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.30.1",
-        "typescript-transformer-esm": "^1.1.0",
         "vitest": "^3.1.1"
     }
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -10,14 +10,10 @@
         "sourceMap": false,
         "removeComments": false,
         "esModuleInterop": false,
-        "plugins": [
-            {
-                "transform": "typescript-transformer-esm",
-                "after": true
-            }
-        ]
     },
-    "include": ["src/**/*"],
+    "include": [
+        "src/**/*"
+    ],
     "exclude": [
         "node_modules",
         "**/*.test.ts",


### PR DESCRIPTION
## Problem
After building the project, ESM imports were missing proper relative paths and `.js` extensions, causing runtime errors when starting the server.

## Solution 2: Babel Post-Processing (This PR)
This PR implements a solution using Babel post-processing that automatically handles any TypeScript path configuration:


- ✅ Flexible solution that handles complex path mappings without additional configuration

## Alternative Solution
See PR #[2](https://github.com/Tenemo/expressplate/pull/2) for a TypeScript-native solution using `typescript-transform-paths` that requires explicit path aliases.

